### PR TITLE
stf trace info eof fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Ubuntu users may need to install the following dependencies for binutils
 ```
 sudo apt-get install libmpc-dev liblzma-dev libbz2-dev
 ```
+May also need to install the following dependencies for libdwarf
+- See: libdwarf [README](https://github.com/davea42/libdwarf-code?tab=readme-ov-file#building-on-linux-from-a-git-clone-with-configureautotools)
+```
+sudo apt-get install autoconf automake libtool pkg-config
+```
 
 ## RISC-V Disassembly Support
 

--- a/tools/stf_trace_info/stf_trace_info.cpp
+++ b/tools/stf_trace_info/stf_trace_info.cpp
@@ -198,8 +198,12 @@ int main (int argc, char **argv) {
     }
 
     if(writer) {
-        while (reader >> rec) {
-            writer << *rec;
+        try {
+            while (reader >> rec) {
+                writer << *rec;
+            }
+        }
+        catch(const stf::EOFException& e) {
         }
     }
 


### PR DESCRIPTION
Minor update to `stf_trace_info` tool to catch EOF exception (similar to other stf_tools) when updating header records.

e.g. 
before fix:
```
[release]$ ./tools/stf_trace_info/stf_trace_info -o /tmp/traces/dhrystone.header.zstf -g 1 -v 0 -c TEST_COMMENT /tmp/traces/dhrystone.zstf 
terminate called after throwing an instance of 'stf::EOFException'
  what():  std::exception
Aborted (core dumped)
```

after fix:
```
[release]$ ./tools/stf_trace_info/stf_trace_info -o /tmp/traces/dhrystone.header.zstf -g 1 -v 0 -c TEST_COMMENT /tmp/traces/dhrystone.zstf 
[release]$ 
```

----

Also, minor update to README to note dependencies from libdwarf that may require installing the specified packages.